### PR TITLE
docs(schema): fix misplaced timestamp description on transaction field

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -72,9 +72,10 @@ type Order implements Event @entity {
   orderJSONString: String!
   expressionJSONString: String
 
-  "Timestamp when the order was added"
+  "Transaction that added the order"
   transaction: Transaction!
   emitter: Account!
+  "Timestamp when the order was added"
   timestamp: BigInt!
 
   "Take Order entities that use this order"


### PR DESCRIPTION
Closes #44

The description "Timestamp when the order was added" was placed before the `transaction` field (making it the description for `transaction`). Move it to precede `timestamp` and add an accurate description for `transaction`.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the order details definition so transaction and emitter information appears earlier in the field listing, improving consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->